### PR TITLE
TreeTagger is integrated as part of plugin-mecab-initcorpus. It uses the

### DIFF
--- a/plugin-mecab-initcorpus/pom.xml
+++ b/plugin-mecab-initcorpus/pom.xml
@@ -28,5 +28,20 @@
 			<artifactId>log4j</artifactId>
 			<version>1.2.17</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-analyzers-common</artifactId>
+			<version>4.7.2</version>
+		</dependency>
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>1.2.17</version>
+		</dependency>
+		<dependency>
+			<groupId>cc.topicexplorer</groupId>
+			<artifactId>lucene-analyzer-treetagger</artifactId>
+			<version>1.0.0</version>
+		</dependency>		
 	</dependencies>
 </project>

--- a/plugin-mecab-initcorpus/src/main/java/cc/topicexplorer/plugin/mecab/initcorpus/command/DocumentTermFill.java
+++ b/plugin-mecab-initcorpus/src/main/java/cc/topicexplorer/plugin/mecab/initcorpus/command/DocumentTermFill.java
@@ -10,6 +10,7 @@ import java.io.UnsupportedEncodingException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -17,37 +18,81 @@ import org.apache.log4j.Logger;
 
 import cc.topicexplorer.commands.TableFillCommand;
 import cc.topicexplorer.plugin.mecab.initcorpus.implementation.postagger.JPOSMeCab;
+import cc.topicexplorer.plugin.mecab.initcorpus.implementation.treetagger.PreparationWithTreeTagger;
 
 import com.google.common.collect.Sets;
 
-
 public class DocumentTermFill extends TableFillCommand {
-	private static final Logger logger = Logger.getLogger(DocumentTermFill.class);
+	private static final Logger logger = Logger
+			.getLogger(DocumentTermFill.class);
 
 	@Override
 	public void fillTable() {
+		String textAnalyzer = properties.getProperty("Mecab_text-analyzer").trim();
+
 		String fileName = "temp/docTerm.sql.csv";
 		File fileTemp = new File(fileName);
-        if (fileTemp.exists()) {
-        	fileTemp.delete();
-        }  
+		if (fileTemp.exists()) {
+			fileTemp.delete();
+		}
 		try {
-			if(!properties.containsKey("Mecab_LibraryPath")) {
-				logger.error("Mecab library path not set. Did you enable mecab plugin in config.properties?");
-				throw new RuntimeException("Mecab library path not set.");
-			}
-			JPOSMeCab jpos = new JPOSMeCab(properties.getProperty("Mecab_LibraryPath").trim(), logger);
-			BufferedWriter docTermCSVWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(fileName, true), "UTF-8"));
-		
-//			ResultSet textRs = database.executeQuery("SELECT " + properties.getProperty("OrgTableId") + 
-//					", " + properties.getProperty("OrgTableTxt") + " FROM " + properties.getProperty("OrgTableName"));
-			Statement stmt = database.getConnection().createStatement(java.sql.ResultSet.TYPE_FORWARD_ONLY, java.sql.ResultSet.CONCUR_READ_ONLY);
-			stmt.setFetchSize(Integer.MIN_VALUE);
-			
-			ResultSet textRs = stmt.executeQuery("SELECT DOCUMENT_ID, DOCUMENT_TEXT FROM orgTable_text");
-			while(textRs.next()) {
-				List<String> csvList = jpos.parseString(textRs.getInt("DOCUMENT_ID"), textRs.getString("DOCUMENT_TEXT"), logger);
+			JPOSMeCab jpos = null;
+			PreparationWithTreeTagger treeTaggerAnalyzer = null;
+			if ("mecab".equals(textAnalyzer)) {
+				if (!properties.containsKey("Mecab_LibraryPath")) {
+					logger.error("Mecab library path not set. Did you enable mecab plugin in config.properties?");
+					throw new RuntimeException("Mecab library path not set.");
+				}
+				jpos = new JPOSMeCab(properties
+						.getProperty("Mecab_LibraryPath").trim(), logger);
+			} else if ("treetagger".equals(textAnalyzer)) {
+				if (!properties.containsKey("Mecab_treetagger-path")
+						|| !properties.containsKey("Mecab_treetagger-model")) {
+					logger.error("TreeTagger path or model not set.");
+					throw new RuntimeException(
+							"TreeTagger path or model not set.");
+				}
+
+				HashMap<String,Integer> tag2id = new HashMap<String,Integer>();
+				Statement posType_stmt = database.getConnection().createStatement(
+						java.sql.ResultSet.TYPE_FORWARD_ONLY,
+						java.sql.ResultSet.CONCUR_READ_ONLY);
+				posType_stmt.setFetchSize(Integer.MIN_VALUE);
+
+				ResultSet posRs = posType_stmt
+						.executeQuery("SELECT POS,DESCRIPTION FROM POS_TYPE;");
+				while (posRs.next()) {
+					tag2id.put(posRs.getString("DESCRIPTION"), posRs.getInt("POS"));
+				}
+				posRs.close();
+				posType_stmt.close();
+
+				treeTaggerAnalyzer = new PreparationWithTreeTagger(',',
+						properties.getProperty("Mecab_treetagger-path").trim(), properties.getProperty("Mecab_treetagger-model").trim(), tag2id);
+
+				treeTaggerAnalyzer.setLogger(org.apache.log4j.Logger.getRootLogger());
 				
+			}
+			BufferedWriter docTermCSVWriter = new BufferedWriter(
+					new OutputStreamWriter(
+							new FileOutputStream(fileName, true), "UTF-8"));
+
+			Statement stmt = database.getConnection().createStatement(
+					java.sql.ResultSet.TYPE_FORWARD_ONLY,
+					java.sql.ResultSet.CONCUR_READ_ONLY);
+			stmt.setFetchSize(Integer.MIN_VALUE);
+
+			ResultSet textRs = stmt
+					.executeQuery("SELECT DOCUMENT_ID, DOCUMENT_TEXT FROM orgTable_text");
+			while (textRs.next()) {
+				List<String> csvList = null;
+				if ("mecab".equals(textAnalyzer)) {
+					csvList = jpos.parseString(textRs.getInt("DOCUMENT_ID"),
+							textRs.getString("DOCUMENT_TEXT"), logger);
+				} else if ("treetagger".equals(textAnalyzer)) {
+					csvList = treeTaggerAnalyzer.parse(textRs.getInt("DOCUMENT_ID"),
+							textRs.getString("DOCUMENT_TEXT"));
+				}
 				for (String csvEntry : csvList) {
 					docTermCSVWriter.write(csvEntry + "\n");
 				}
@@ -55,14 +100,16 @@ public class DocumentTermFill extends TableFillCommand {
 			docTermCSVWriter.flush();
 			docTermCSVWriter.close();
 
-			database.executeUpdateQuery("LOAD DATA LOCAL INFILE '" + fileName + "' IGNORE INTO TABLE "
-					+ tableName + " CHARACTER SET utf8 FIELDS TERMINATED BY ',' ENCLOSED BY '\"' (`DOCUMENT_ID`, "
+			database.executeUpdateQuery("LOAD DATA LOCAL INFILE '"
+					+ fileName
+					+ "' IGNORE INTO TABLE "
+					+ tableName
+					+ " CHARACTER SET utf8 FIELDS TERMINATED BY ',' ENCLOSED BY '\"' (`DOCUMENT_ID`, "
 					+ "`POSITION_OF_TOKEN_IN_DOCUMENT`, `TERM`, `TOKEN`, `WORDTYPE_CLASS`, `CONTINUATION`);");
 			stmt.close();
-			
+
 			database.executeUpdateQuery("CREATE INDEX TERM_WORDCLASS ON DOCUMENT_TERM(TERM,WORDTYPE_CLASS,DOCUMENT_ID)");
-		      
-			
+
 		} catch (SQLException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -90,7 +137,7 @@ public class DocumentTermFill extends TableFillCommand {
 
 	@Override
 	public Set<String> getBeforeDependencies() {
-		return Sets.newHashSet("DocumentTermCreate");
+		return Sets.newHashSet("DocumentTermCreate","PosTypeFill");
 	}
 
 	@Override

--- a/plugin-mecab-initcorpus/src/main/java/cc/topicexplorer/plugin/mecab/initcorpus/command/PosTypeCreate.java
+++ b/plugin-mecab-initcorpus/src/main/java/cc/topicexplorer/plugin/mecab/initcorpus/command/PosTypeCreate.java
@@ -40,6 +40,7 @@ public class PosTypeCreate  extends TableCreateCommand{
 					+ "`LOW` int(11) DEFAULT NULL,"
 					+ "`HIGH` int(11) DEFAULT NULL, "
 					+ "`DESCRIPTION` varchar(255), "
+					+ "`LONG_DESCRIPTION` varchar(255) DEFAULT 'unknown', "
 					+ "`PARENT_POS` int(11) DEFAULT NULL, "
 					+ "TOKEN_COUNT int(11) DEFAULT NULL, "
 					+ "DOCUMENT_COUNT int(11) DEFAULT NULL, "

--- a/plugin-mecab-initcorpus/src/main/java/cc/topicexplorer/plugin/mecab/initcorpus/command/PosTypeFill.java
+++ b/plugin-mecab-initcorpus/src/main/java/cc/topicexplorer/plugin/mecab/initcorpus/command/PosTypeFill.java
@@ -34,7 +34,10 @@ public class PosTypeFill extends TableFillCommand {
 
 	@Override
 	public void fillTable() {
+		String textAnalyzer = properties.getProperty("Mecab_text-analyzer").trim();
+
 		try {
+			if ("mecab".equals(textAnalyzer)) {
 			this.database.executeUpdateQuery("INSERT INTO " + this.tableName
 					+ " (`POS`, `LOW`, `HIGH`, `DESCRIPTION`, `PARENT_POS`) VALUES "
 					+ "(0, 1000, 1999, '間投', 100),"
@@ -122,7 +125,141 @@ public class PosTypeFill extends TableFillCommand {
 					+ "(113, 72000, 74999, '代名詞', 108),"
 					+ "(114, 76000, 77999, '特殊', 108),"
 					+ "(115, 78000, 82999, '非自立', 108)");
-		} catch (SQLException e) {
+			} else if ("treetagger".equals(textAnalyzer)) {
+				String treeTaggerModel = properties.getProperty("Mecab_treetagger-model").trim();
+				if ("/german-utf8.par".equals(treeTaggerModel)) {
+					this.database.executeUpdateQuery("INSERT INTO POS_TYPE"+
+							"(`POS`, `LOW`, `HIGH`, `DESCRIPTION`, `LONG_DESCRIPTION`, `PARENT_POS`) VALUES "+
+							"(0, 0, 999, 'N', 'Nomen', -1),"+
+							"(113, 0, 99, 'NN', 'normales Nomen', 0),"+
+							"(114, 100, 199, 'NE', 'Eigennamen', 0),"+
+							"(1, 1000, 1999, 'V', 'Verben', -1),"+
+							"(135, 1000, 1099, 'VV', 'Verben voll', 1),"+
+							"(138, 1000, 1009, 'VVFIN', 'finites Verb, voll', 135),"+
+							"(139, 1010, 1019, 'VVIMP', 'Imperativ, voll', 135),"+
+							"(140, 1020, 1029, 'VVINF', 'Infinitiv, voll', 135),"+
+							"(141, 1030, 1039, 'VVIZU', 'Infinitiv mit zu, voll', 135),"+
+							"(142, 1040, 1049, 'VVPP', 'Partizip Perfekt, voll', 135),"+
+							"(136, 1100, 1199, 'VA', 'Verben aux', 1),"+
+							"(143, 1100, 1199, 'VAFIN', 'finites Verb, aux', 136),"+
+							"(144, 1100, 1199, 'VAIMP', 'Imperativ, aux', 136),"+
+							"(145, 1100, 1199, 'VAINF', 'Infinitiv, aux', 136),"+
+							"(147, 1100, 1199, 'VAPP', 'Partizip Perfekt, aux', 136),"+
+							"(137, 1200, 1299, 'VM', 'Verben modal', 1),"+
+							"(148, 1200, 1299, 'VMFIN', 'finites Verb, modal', 137),"+
+							"(149, 1200, 1299, 'VMINF', 'Infinitiv, modal', 137),"+
+							"(150, 1200, 1299, 'VMPP', 'Partizip Perfekt, modal', 137),"+
+							"(2, 2000, 2999, 'ART', 'Artikel', -1),"+
+							"(3, 3000, 3999, 'ADJ', 'Adjektive', -1),"+
+							"(100, 3000, 3499, 'ADJA', 'attributives Adjektiv', 3),"+
+							"(101, 3500, 3999, 'ADJD', 'adverbiales oder pradikatives Adjektiv', 3),"+
+							"(4, 4000, 4009, 'P', 'Pronomina', -1),"+
+							"(115, 4010, 4019, 'PDS', 'substituierendes Demonstrativpronomen', 4),"+
+							"(116, 4020, 4029, 'PDAT', 'attribuierendes Demonstrativpronomen', 4),"+
+							"(117, 4030, 4039, 'PIS', 'substituierendes Indefinitpronomen', 4),"+
+							"(118, 4040, 4049, 'PIAT', 'attribuierendes Indefinitpronomen ohne Determiner', 4),"+
+							"(119, 4050, 4059, 'PIDAT', 'attribuierendes Indefinitpronomen mit Determiner', 4),"+
+							"(120, 4060, 4069, 'PPER', 'irreflexives Personalpronomen', 4),"+
+							"(121, 4070, 4079, 'PPOSS', 'substituierendes Possessivpronomen', 4),"+
+							"(122, 4080, 4089, 'PPOSAT', 'attribuierendes Possessivpronomen', 4),"+
+							"(123, 4090, 4099, 'PRELS', 'Relativpronomen substituierend', 4),"+
+							"(124, 4100, 4109, 'PRELAT', 'Relativpronomen attribuierend', 4),"+
+							"(125, 4110, 4119, 'PRF', 'reflexives Personalpronomen', 4),"+
+							"(126, 4120, 4129, 'PWS', 'substituierendes Interrogativpronomen', 4),"+
+							"(127, 4130, 4139, 'PWAT', 'attribuierendes Interrogativpronomen', 4),"+
+							"(128, 4140, 4149, 'PWAV', 'adverbiales Interrogativ- oder Relativpronomen', 4),"+
+							"(129, 4150, 4159, 'PAV', 'Pronominaladverb', 4),"+
+							"(5, 5000, 5999, 'CARD', 'Kardinalzahlen', -1),"+
+							"(6, 6000, 6999, 'ADV', 'Adverbien', -1),"+
+							"(7, 7000, 7999, 'KO', 'Konjunktionen', -1),"+
+							"(109, 7000, 7099, 'KOUI', 'unterordnende Konjunktion mit zu und Infinitiv', 7),"+
+							"(110, 7100, 7199, 'KOUS', 'unterordnende Konjunktion mit Satz', 7),"+
+							"(111, 7200, 7299, 'KON', 'nebenordnende Konjunktion', 7),"+
+							"(112, 7300, 7399, 'KOKOM', 'Vergleichspartikel, ohne Satz', 7),"+
+							"(8, 8000, 8999, 'AP', 'Adpositionen', -1),"+
+							"(102, 8000, 8099, 'APPR', 'Praposition; Zirkumposition links',8),"+
+							"(103, 8100, 8199, 'APPRART', 'Praposition mit Artikel',8),"+
+							"(104, 8200, 8299, 'APPO', 'Postposition',8),"+
+							"(105, 8300, 8399, 'APZR', 'Zirkumposition rechts',8),"+
+							"(9, 9000, 9999, 'ITJ', 'Interjektionen', -1),"+
+							"(10, 10000, 10999, 'PTK', 'Partikeln', -1),"+
+							"(130, 10000, 10099, 'PTKZU', 'zu vor Infinitiv', 10),"+
+							"(131, 10100, 10199, 'PTKNEG', 'Negationspartikel', 10),"+
+							"(132, 10200, 10299, 'PTKVZ', 'abgetrennter Verbzusatz', 10),"+
+							"(133, 10300, 10399, 'PTKANT', 'Antwortpartikel', 10),"+
+							"(134, 10400, 10499, 'PTKA', 'Partikel bei Adjektiv oder Adverb', 10),"+
+							"(11, 11000, 11999, 'FM', 'Fremdsprachliches Material', -1),"+
+							"(12, 12000, 12999, 'TRUNC', 'KompositionsErstglieder', -1),"+
+							"(13, 13000, 13999, 'XY', 'Nichtworter', -1),"+
+							"(14, 14000, 14999, '$,', 'Komma', -1),"+
+							"(15, 15000, 15999, '$.', 'Satzende', -1),"+
+							"(16, 16000, 16999, '$(', 'Sonstiges Satzzeichen', -1)"+
+							";"
+                      );
+				} else if ("/english-utf8.par".equals(treeTaggerModel)) {
+					this.database.executeUpdateQuery("INSERT INTO POS_TYPE"+
+							"(POS,LOW,HIGH,DESCRIPTION,LONG_DESCRIPTION,PARENT_POS) VALUES "+
+							"(1,1000,1999, 'CC', 'Coordinating conjunction',-1),"+
+							"(2,2000,2999, 'CD', 'Cardinal number',-1),"+
+							"(3,3000,3999, 'DT', 'Determiner',-1),"+
+							"(4,4000,4999, 'EX', 'Existential there',-1),"+
+							"(5,5000,5999, 'FW', 'Foreign word',-1),"+
+							"(6,6000,6999, 'IN', 'Preposition or subordinating conjunction',-1),"+
+							"(7,7000,7999, 'JJ', 'Adjective',-1),"+
+							"(8,7100,7199, 'JJR', 'Adjective, comparative',7),"+
+							"(9,7200,7299, 'JJS', 'Adjective, superlative',7),"+
+							"(10,8000,1999, 'LS', 'List item marker',-1),"+
+							"(11,9000,1999, 'MD', 'Modal verb',-1),"+
+							"(12,10000,10999, 'N', 'Noun, general',-1),"+
+							"(13,10000,10599, 'NO', 'Noun, but not proper noun',12),"+
+							"(14,10000,10299, 'NN', 'Noun, singular or mass',13),"+
+							"(15,10300,10399, 'NNS', 'Noun, plural',13),"+
+							"(16,10600,10999, 'NOP', 'Proper noun, general',12),"+
+							"(17,10600,10799, 'NP', 'Proper noun, singular',16),"+
+							"(18,10800,10899, 'NPS', 'Proper noun, plural',16),"+
+							"(19,11000,11999, 'PDT', 'Predeterminer',-1),"+
+							"(20,12000,12999, 'POS', 'Possessive ending',-1),"+
+							"(21,13000,13999, 'PP', 'Personal pronoun',-1),"+
+							"(22,14000,14999, 'PP$', 'Possessive pronoun',-1),"+
+							"(23,15000,15999, 'RB', 'Adverb',-1),"+
+							"(24,15000,15599, 'RBR', 'Adverb, comparative',23),"+
+							"(25,15600,15999, 'RBS', 'Adverb, superlative',23),"+
+							"(26,16000,16999, 'RP', 'Particle',-1),"+
+							"(27,17000,17999, 'SYM', 'Symbol',-1),"+
+							"(28,18000,18999, 'TO', 'to',-1),"+
+							"(29,19000,19999, 'UH', 'Interjection',-1),"+
+							"(30,20000,20999, 'V', 'Verb, general',-1),"+
+							"(31,20000,20009, 'VB', 'Verb be, base form',30),"+
+							"(32,20010,20019, 'VBD', 'Verb be, past tense',30),"+
+							"(33,20020,20029, 'VBG', 'Verb be, gerund or present participle',30),"+
+							"(34,20030,20039, 'VBN', 'Verb be, past participle',30),"+
+							"(35,20040,20049, 'VBP', 'Verb be, non-3rd person singular present',30),"+
+							"(36,20050,20059, 'VBZ', 'Verb be, 3rd person singular present',30),"+
+							"(37,20060,20069, 'VV', 'Verb, base form',30),"+
+							"(38,20070,20079, 'VVD', 'Verb, past tense',30),"+
+							"(39,20080,20089, 'VVG', 'Verb, gerund or present participle',30),"+
+							"(40,20090,20099, 'VVN', 'Verb, past participle',30),"+
+							"(41,20100,20109, 'VVP', 'Verb, non-3rd person singular present',30),"+
+							"(42,20110,20119, 'VVZ', 'Verb, 3rd person singular present',30),"+
+							"(43,20120,20129, 'VH', 'Verb have, base form',30),"+
+							"(44,20130,20139, 'VHD', 'Verb have, past tense',30),"+
+							"(45,20140,20149, 'VHG', 'Verb have, gerund or present participle',30),"+
+							"(46,20150,20159, 'VHN', 'Verb have, past participle',30),"+
+							"(47,20160,20169, 'VHP', 'Verb have, non-3rd person singular present',30),"+
+							"(48,20170,20179, 'VHZ', 'Verb have, 3rd person singular present',30),"+
+							"(49,21000,21999, 'WDT', 'Wh-determiner',-1),"+
+							"(50,22000,22999, 'WP', 'Wh-pronoun',-1),"+
+							"(51,23000,23999, 'WP$', 'Possessive wh-pronoun',-1),"+
+							"(52,24000,24999, 'WRB', 'Wh-adverb',-1),"+ 
+							"(53,25000,25999, 'IN/that', 'Preposition or subordinating conjunction',-1);"
+							);
+//					VHZ
+				}
+				
+				
+			}
+			
+			} catch (SQLException e) {
 			logger.error("Table " + this.tableName + " could not be filled.");
 			throw new RuntimeException(e);
 		}

--- a/plugin-mecab-initcorpus/src/main/java/cc/topicexplorer/plugin/mecab/initcorpus/implementation/treetagger/PreparationWithTreeTagger.java
+++ b/plugin-mecab-initcorpus/src/main/java/cc/topicexplorer/plugin/mecab/initcorpus/implementation/treetagger/PreparationWithTreeTagger.java
@@ -1,0 +1,106 @@
+package cc.topicexplorer.plugin.mecab.initcorpus.implementation.treetagger;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.log4j.Logger;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+
+import cc.topicexplorer.lucene.analyzer.treetagger.TreeTaggerAnalyzer;
+
+import com.google.common.base.Joiner;
+
+public class PreparationWithTreeTagger {
+	private String outToken;
+	private String outTerm;
+	private String outWordType;
+	private Integer outStartPosition;
+
+	private char outCSVSeparator;
+	private HashMap<String,Integer> tag2id;
+	private static Logger logger;
+	private static Pattern colonTokenPattern = Pattern.compile("Token:(.*)");
+	private static Pattern colonLemmaPattern = Pattern.compile("Lemma:(.*)");
+	private static Matcher matcher;
+
+	private TreeTaggerAnalyzer analyzer;
+
+	public PreparationWithTreeTagger(char outCSVSeparator,
+			String pathToTreeTagger, String treeTaggerModel, HashMap<String,Integer> tag2id) {
+		this.outToken = new String();
+		this.outTerm = new String();
+		this.outWordType = new String();
+		this.outStartPosition = new Integer(0);
+		this.outCSVSeparator = outCSVSeparator;
+		this.analyzer = new TreeTaggerAnalyzer(pathToTreeTagger,
+				treeTaggerModel);
+		this.tag2id = tag2id;
+	}
+
+	public void setLogger(Logger logger) {
+		PreparationWithTreeTagger.logger = logger;
+	}
+
+
+	public List<String> parse(Integer outDocumentId, String fullText)
+			throws IOException {
+
+		ArrayList<String> out = new ArrayList<String>();
+		logger.info("Document:" + outDocumentId);
+		final TokenStream tokenStream = this.analyzer.tokenStream("testField",
+				fullText);
+
+		OffsetAttribute offsetAttribute = tokenStream
+				.addAttribute(OffsetAttribute.class);
+		CharTermAttribute charTermAttribute = tokenStream
+				.addAttribute(CharTermAttribute.class);
+		TypeAttribute typeAttribute = tokenStream
+				.addAttribute(TypeAttribute.class);
+
+		tokenStream.reset();
+		// A TreeTagger stream produces alternating token and lemma
+		// indicated by same startOffset.
+		while (tokenStream.incrementToken()) {
+			this.outStartPosition = offsetAttribute.startOffset();
+			matcher = colonTokenPattern.matcher(typeAttribute.type());
+			if (matcher.find()) {
+				this.outWordType = matcher.group(1);
+			}
+			this.outToken = charTermAttribute.toString();
+			if (!tokenStream.incrementToken()) {
+				logger.error("Uneven number of token produced by TreeTagger-Analyzer");
+				break;
+			}
+			this.outTerm = charTermAttribute.toString();
+			matcher = colonLemmaPattern.matcher(typeAttribute.type());
+			String lemmaType = "";
+			if (matcher.find()) {
+				lemmaType = matcher.group(1);
+			}
+
+			if (!this.outStartPosition.equals(offsetAttribute.startOffset())
+					|| !this.outWordType.equals(lemmaType)) {
+				logger.error("Position or type of respective token and term produced by TreeTagger-Analyzer are not matching.");
+				break;
+			}
+			if (!this.tag2id.containsKey(outWordType)) {
+				logger.error("Pos tag " + outWordType + " is not in table POS_TYPE");
+				throw new RuntimeException();
+			}
+			String[] outRecord = { outDocumentId.toString(),
+					outStartPosition.toString(), "\""+outTerm+"\"", "\""+outToken+"\"", this.tag2id.get(outWordType).toString() };
+
+			out.add(Joiner.on(this.outCSVSeparator).join(outRecord));
+		}
+		tokenStream.close();
+		return out;
+	}
+
+}

--- a/plugin-mecab-initcorpus/src/main/resources/mecab.global.properties
+++ b/plugin-mecab-initcorpus/src/main/resources/mecab.global.properties
@@ -1,4 +1,11 @@
+text-analyzer=mecab
+#text-analyzer=treetagger
 #mac
 LibraryPath=/opt/local/lib/libmecab-java.dylib
 #linux
 #LibraryPath=/usr/lib/jni/libMeCab.so
+
+#TreeTagger Properties, need to be moved in the next refactoring
+ treetagger-path=/path/to/TreeTagger
+ treetagger-model=/german-utf8.par
+ #treetagger-model=/english-utf8.par


### PR DESCRIPTION
lucene-analyzer-treetagger by Alexander Hinneburg that transforms the
output of treetagger into lucence analyzer token stream. This would
prove helpful, when lucene is used for keyword searching instead of
mysql.

At the moment, there is a switch in mecab.global.properties that allows
to choose among mecab and treetagger with German and English dictionary.
For those two dicts the respective table contents of PosType are
provided in PosTypeFill command.

The table PosType is extended by attribute LONG_DESCRIPTION that
contains a verbal explanation of the POS tag. This will be used by
webapp-preprocessing for explaining POS tags.

The current state allows to run webapp-prepocessing without
modification. A refactoring of plugin-mecab-initcorpus is neccessary to
isolate common parts of text preprocessing and the mecab and treetagger
specifics.
